### PR TITLE
update template to remove signature if empty

### DIFF
--- a/default.go
+++ b/default.go
@@ -446,11 +446,13 @@ func (dt *Default) HTMLTemplate() string {
                         {{ end }}
                       {{ end }}
 
-                    <p>
+										{{ if (ne .Email.Body.Signature " ") }}
+										<p>
                       {{.Email.Body.Signature}},
                       <br />
                       {{.Hermes.Product.Name}}
                     </p>
+										{{ end }}
 
                     {{ if (eq .Email.Body.FreeMarkdown "") }}
                       {{ with .Email.Body.Actions }} 
@@ -557,7 +559,7 @@ func (dt *Default) PlainTextTemplate() string {
     <p>{{ $line }}<p>
   {{ end }}
 {{ end }}
-<p>{{.Email.Body.Signature}},<br>{{.Hermes.Product.Name}} - {{.Hermes.Product.Link}}</p>
+{{ if (ne .Email.Body.Signature " ") }}<p>{{.Email.Body.Signature}},<br>{{.Hermes.Product.Name}} - {{.Hermes.Product.Link}}</p>{{ end }}
 
 <p>{{.Hermes.Product.Copyright}}</p>
 `


### PR DESCRIPTION
The current email template for `Hermes` always includes the signature line at the end even if not desired. This makes it disappear if the signature is empty.